### PR TITLE
Handle element sizing in rich text lines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.logi.composer</groupId>
     <artifactId>boxable</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <packaging>jar</packaging>
 
     <name>Boxable, a high-level API to creates table on top of Apache Pdfbox</name>

--- a/src/main/java/be/quodlibet/boxable/richtext/RichTextLine.java
+++ b/src/main/java/be/quodlibet/boxable/richtext/RichTextLine.java
@@ -80,4 +80,35 @@ public final class RichTextLine {
         }
         return max;
     }
+
+    /**
+     * Returns the maximum font size across <em>text-only</em> elements
+     * ({@link RichTextSegment}s), ignoring inline images.
+     * Used for sizing the bullet/number prefix glyph so that it matches
+     * the body text rather than being inflated by a large inline image.
+     * Falls back to {@link #getMaxFontSize()} when there are no text segments.
+     */
+    public float getTextMaxFontSize() {
+        float max = 6f; // minimum floor
+        for (LineElement el : elements) {
+            if (el instanceof RichTextSegment) {
+                float h = el.getHeight();
+                if (h > max) {
+                    max = h;
+                }
+            }
+        }
+        // If there are no text segments, fall back to the global max
+        // so that non-text list items still get a reasonable prefix size.
+        boolean hasTextSegment = false;
+        for (LineElement el : elements) {
+            if (el instanceof RichTextSegment) {
+                hasTextSegment = true;
+                break;
+            }
+        }
+        return hasTextSegment ? max : getMaxFontSize();
+    }
+
 }
+

--- a/src/main/java/be/quodlibet/boxable/richtext/TextContentElement.java
+++ b/src/main/java/be/quodlibet/boxable/richtext/TextContentElement.java
@@ -70,8 +70,10 @@ public final class TextContentElement implements ContentElement {
     // ── Internals ────────────────────────────────────────────────────────
 
     private float estimateLineHeight(RichTextLine line, float availableWidth) throws IOException {
-        float fontSize = line.getMaxFontSize();
-        float lineHeight = fontSize * LINE_SPACING;
+        // Inter-line gap is proportional to text size, not image size.
+        // For text-only lines this equals getMaxFontSize() * LINE_SPACING (unchanged).
+        // For lines with tall images the gap stays at text size * 0.4 instead of image height * 0.4.
+        float lineHeight = line.getMaxFontSize() + line.getTextMaxFontSize() * (LINE_SPACING - 1);
 
         float contentWidth = availableWidth;
         if (line.getListType() == ListType.BULLETED || line.getListType() == ListType.NUMBERED) {
@@ -83,8 +85,12 @@ public final class TextContentElement implements ContentElement {
     }
 
     private void renderLine(RenderContext ctx, RichTextLine line) throws IOException {
-        float fontSize = line.getMaxFontSize();
-        float lineHeight = fontSize * LINE_SPACING;
+        // lineHeight: image/content height + text-proportional inter-line gap.
+        // Using getTextMaxFontSize() for the gap factor keeps spacing consistent regardless
+        // of image height, while getMaxFontSize() ensures the full image fits in the line.
+        float lineHeight = line.getMaxFontSize() + line.getTextMaxFontSize() * (LINE_SPACING - 1);
+        // fontSize is used only for the bullet/number prefix glyph (text size only).
+        float fontSize = line.getTextMaxFontSize();
         float contentStartX = ctx.getLeft();
         float contentWidth = ctx.getInnerWidth();
 

--- a/src/test/java/be/quodlibet/boxable/richtext/RichTextLineTest.java
+++ b/src/test/java/be/quodlibet/boxable/richtext/RichTextLineTest.java
@@ -1,0 +1,175 @@
+package be.quodlibet.boxable.richtext;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link RichTextLine} font-size query methods.
+ */
+public class RichTextLineTest {
+
+    private static final float DELTA = 0.001f;
+
+    // ── getMaxFontSize ───────────────────────────────────────────────────
+
+    @Test
+    public void getMaxFontSize_textOnly_returnsLargestSegmentFontSize() {
+        RichTextLine line = lineOf(
+                segment("small", 8f),
+                segment("large", 14f),
+                segment("medium", 10f)
+        );
+
+        assertEquals(14f, line.getMaxFontSize(), DELTA);
+    }
+
+    @Test
+    public void getMaxFontSize_withInlineImage_returnsImageHeightWhenTaller() throws IOException, URISyntaxException {
+        InlineImageSegment bigImage = loadPng(100f, 60f); // 60pt tall image
+
+        RichTextLine line = lineOf(segment("text", 10f), bigImage);
+
+        // Image height (60) > text font size (10) → max is image height
+        assertEquals(60f, line.getMaxFontSize(), DELTA);
+    }
+
+    // ── getTextMaxFontSize ────────────────────────────────────────────────
+
+    @Test
+    public void getTextMaxFontSize_textOnly_returnsLargestSegmentFontSize() {
+        RichTextLine line = lineOf(
+                segment("small", 8f),
+                segment("large", 14f),
+                segment("medium", 10f)
+        );
+
+        assertEquals(14f, line.getTextMaxFontSize(), DELTA);
+    }
+
+    @Test
+    public void getTextMaxFontSize_textPlusLargeImage_returnsTextMaxNotImageHeight()
+            throws IOException, URISyntaxException {
+        InlineImageSegment bigImage = loadPng(100f, 60f); // 60pt tall image
+
+        RichTextLine line = lineOf(segment("text", 10f), bigImage);
+
+        // getMaxFontSize() is 60 (image height wins)
+        assertEquals(60f, line.getMaxFontSize(), DELTA);
+        // getTextMaxFontSize() must ignore the image and return text-only max
+        assertEquals(10f, line.getTextMaxFontSize(), DELTA);
+    }
+
+    @Test
+    public void getTextMaxFontSize_multipleTextSegmentsPlusImage_returnsLargestTextSize()
+            throws IOException, URISyntaxException {
+        InlineImageSegment bigImage = loadPng(100f, 60f); // 60pt tall image
+
+        RichTextLine line = lineOf(
+                segment("small", 8f),
+                segment("large", 14f),
+                bigImage,
+                segment("medium", 10f)
+        );
+
+        assertEquals(14f, line.getTextMaxFontSize(), DELTA);
+    }
+
+    @Test
+    public void getTextMaxFontSize_imageOnly_fallsBackToGetMaxFontSize()
+            throws IOException, URISyntaxException {
+        InlineImageSegment img = loadPng(80f, 50f); // 50pt tall image
+
+        RichTextLine line = lineOf(img);
+
+        // No text segments → fallback to getMaxFontSize()
+        assertEquals(line.getMaxFontSize(), line.getTextMaxFontSize(), DELTA);
+    }
+
+    @Test
+    public void getTextMaxFontSize_emptyLine_returnsMinimumFloor() {
+        RichTextLine line = new RichTextLine(
+                Collections.emptyList(), ListType.NONE, 0, TextAlignment.LEFT);
+
+        // Both methods apply the same 6f floor
+        assertEquals(line.getMaxFontSize(), line.getTextMaxFontSize(), DELTA);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that inter-line spacing for a mixed text+image line scales with
+     * the TEXT font size, not the image height.
+     * <p>
+     * Formula: lineHeight = imageHeight + textFontSize * (LINE_SPACING - 1)
+     * </p>
+     */
+    @Test
+    public void lineHeight_withLargeInlineImage_spacingProportionalToTextNotImage()
+            throws IOException, URISyntaxException {
+        float textFontSize = 10f;
+        float imageHeight = 60f;
+        float lineSpacingFactor = TextContentElement.LINE_SPACING - 1; // 0.4
+
+        InlineImageSegment bigImage = loadPng(100f, imageHeight);
+        RichTextLine line = lineOf(segment("text", textFontSize), bigImage);
+
+        // Expected: image fits + text-proportional gap
+        float expectedLineHeight = imageHeight + textFontSize * lineSpacingFactor; // 64pt
+        float oldLineHeight = imageHeight * TextContentElement.LINE_SPACING;       // 84pt (old behaviour)
+
+        // The new lineHeight must equal the expected formula
+        assertEquals(expectedLineHeight, line.getMaxFontSize() + line.getTextMaxFontSize() * lineSpacingFactor, DELTA);
+
+        // And must be smaller than the old formula (less excessive spacing above)
+        assertTrue("New line height should be less than old formula",
+                expectedLineHeight < oldLineHeight);
+    }
+
+    /**
+     * Verifies that text-only line height is unaffected by the formula change.
+     */
+    @Test
+    public void lineHeight_textOnly_unchangedByFormula() {
+        float textFontSize = 10f;
+        float lineSpacingFactor = TextContentElement.LINE_SPACING - 1; // 0.4
+
+        RichTextLine line = lineOf(segment("text", textFontSize));
+
+        // getMaxFontSize() == getTextMaxFontSize() for text-only lines
+        float newFormula = line.getMaxFontSize() + line.getTextMaxFontSize() * lineSpacingFactor;
+        float oldFormula = line.getMaxFontSize() * TextContentElement.LINE_SPACING;
+
+        assertEquals("Text-only line height must be identical under both formulas",
+                oldFormula, newFormula, DELTA);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private static RichTextSegment segment(String text, float fontSize) {
+        return new RichTextSegment(text, EnumSet.noneOf(TextStyle.class), fontSize);
+    }
+
+    @SafeVarargs
+    private static <E extends LineElement> RichTextLine lineOf(E... elements) {
+        return new RichTextLine(Arrays.asList(elements), ListType.NONE, 0, TextAlignment.LEFT);
+    }
+
+    private static InlineImageSegment loadPng(float widthPt, float heightPt)
+            throws IOException, URISyntaxException {
+        return InlineImageSegment.fromFile(
+                Paths.get(Objects.requireNonNull(
+                        RichTextLineTest.class.getResource("/150dpi.png")).toURI()).toFile(),
+                widthPt, heightPt);
+    }
+}


### PR DESCRIPTION
Changed the font-size calculation logic for list type data, to consider text type and image type separately, to avoid bullet/number from bloating to a huge size